### PR TITLE
supress debug output, compiler warns

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -15,8 +15,8 @@ project(jk2)
 set(CMAKE_BUILD_TYPE "RELEASE")
 # set(CMAKE_BUILD_TYPE "DEBUG")
 
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -g -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -16,10 +16,10 @@ set(CMAKE_BUILD_TYPE "RELEASE")
 # set(CMAKE_BUILD_TYPE "DEBUG")
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -Wno-invalid-offsetof -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-cpp -Wno-overflow -g -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -Wno-invalid-offsetof -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")
 
 set(GAME_SOURCE_FILES
                 Ratl/ratl.cpp

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -15,11 +15,11 @@ project(jk2)
 set(CMAKE_BUILD_TYPE "RELEASE")
 # set(CMAKE_BUILD_TYPE "DEBUG")
 
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
 
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -g -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-cpp -Wno-overflow -g -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")
 
 set(GAME_SOURCE_FILES
                 Ratl/ratl.cpp

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -15,7 +15,7 @@ project(jk2)
 set(CMAKE_BUILD_TYPE "RELEASE")
 # set(CMAKE_BUILD_TYPE "DEBUG")
 
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD_PRECACHE")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-overflow -Wno-invalid-offsetof -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-overflow -g -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -15,11 +15,11 @@ project(jk2)
 set(CMAKE_BUILD_TYPE "RELEASE")
 # set(CMAKE_BUILD_TYPE "DEBUG")
 
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-cpp -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -Wno-invalid-offsetof -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-overflow -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG -DFINAL_BUILD")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-overflow -Wno-invalid-offsetof -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG -DFINAL_BUILD")
 
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-cpp -Wno-overflow -g -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-write-strings -Wno-conversion-null -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-cpp -Wno-overflow -Wno-invalid-offsetof -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-int-to-pointer-cast -Wno-overflow -g -fexceptions -m32 -ffast-math -DLINUX -DNDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-write-strings -Wno-pointer-arith -Wno-multichar -Wno-enum-compare -Wno-overflow -Wno-invalid-offsetof -fexceptions -m32 -ffast-math -fno-operator-names -DLINUX -DNDEBUG")
 
 set(GAME_SOURCE_FILES
                 Ratl/ratl.cpp

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -1334,7 +1334,8 @@ void CL_KeyEvent (int key, qboolean down, unsigned time) {
 			return;
 		}
 
-#ifdef FINAL_BUILD
+//was FINAL_BUILD, but do we really want to hide the console like that? -Steve
+#ifdef FINAL_BUILD_CONSOLE 
 		if (!(cls.keyCatchers & KEYCATCH_CONSOLE) && !kg.keys[A_SHIFT].down )	//we're not in the console
 		{//so we require the control keys to get in
 			return;

--- a/code/client/snd_ambient.cpp
+++ b/code/client/snd_ambient.cpp
@@ -270,7 +270,7 @@ static void AS_GetTimeBetweenWaves( ambientSet_t &set )
 	int		startTime, endTime;
 
 	//Get the data
-	sscanf( parseBuffer+parsePos, "%s %d %d", &tempBuffer, &startTime, &endTime );
+	sscanf( parseBuffer+parsePos, "%s %d %d", tempBuffer, &startTime, &endTime );
 
 	//Check for swapped start / end
 	if ( startTime > endTime )
@@ -304,7 +304,7 @@ static void AS_GetSubWaves( ambientSet_t &set )
 	char	dirBuffer[512], waveBuffer[256], waveName[1024];
 
 	//Get the directory for these sets
-	sscanf( parseBuffer+parsePos, "%s %s", &tempBuffer, &dirBuffer );	
+	sscanf( parseBuffer+parsePos, "%s %s", tempBuffer, dirBuffer );	
 
 	//Move the pointer past these two strings
 	parsePos += ((strlen(keywordNames[SET_KEYWORD_SUBWAVES])+1) + (strlen(dirBuffer)+1));
@@ -313,7 +313,7 @@ static void AS_GetSubWaves( ambientSet_t &set )
 	while ( parsePos <= parseSize )
 	{
 		//Get the data
-		sscanf( parseBuffer+parsePos, "%s", &waveBuffer );
+		sscanf( parseBuffer+parsePos, "%s", waveBuffer );
 
 		if ( set.numSubWaves > MAX_WAVES_PER_GROUP )
 		{
@@ -365,7 +365,7 @@ static void AS_GetLoopedWave( ambientSet_t &set )
 	char	waveBuffer[256], waveName[1024];
 
 	//Get the looped wave name
-	sscanf( parseBuffer+parsePos, "%s %s", &tempBuffer, &waveBuffer );
+	sscanf( parseBuffer+parsePos, "%s %s", tempBuffer, waveBuffer );
 
 	//Construct the wave name
 	strcpy( (char *) waveName, "sound/" );
@@ -395,7 +395,7 @@ static void AS_GetVolumeRange( ambientSet_t &set )
 	int		min, max;
 
 	//Get the data
-	sscanf( parseBuffer+parsePos, "%s %d %d", &tempBuffer, &min, &max );
+	sscanf( parseBuffer+parsePos, "%s %d %d", tempBuffer, &min, &max );
 
 	//Check for swapped min / max
 	if ( min > max )
@@ -425,7 +425,7 @@ AS_GetRadius
 static void AS_GetRadius( ambientSet_t &set )
 {
 	//Get the data
-	sscanf( parseBuffer+parsePos, "%s %d", &tempBuffer, &set.radius );
+	sscanf( parseBuffer+parsePos, "%s %d", tempBuffer, &set.radius );
 
 	AS_SkipLine();
 }
@@ -443,11 +443,11 @@ static void AS_GetGeneralSet( ambientSet_t &set )
 	//The other parameters of the set come in a specific order
 	while ( parsePos <= parseSize )
 	{
-		int iFieldsScanned = sscanf( parseBuffer+parsePos, "%s", &tempBuffer );
+		int iFieldsScanned = sscanf( parseBuffer+parsePos, "%s", tempBuffer );
 		if (iFieldsScanned <= 0)
 			return;
 
-		keywordID = AS_GetKeywordIDForString( (const char *) &tempBuffer );
+		keywordID = AS_GetKeywordIDForString( (const char *) tempBuffer );
 
 		//Find and parse the keyword info
 		switch ( keywordID )
@@ -471,7 +471,7 @@ static void AS_GetGeneralSet( ambientSet_t &set )
 		default:
 
 			//Check to see if we've finished this group
-			if ( AS_GetSetNameIDForString( (const char *) &tempBuffer ) == -1 )
+			if ( AS_GetSetNameIDForString( (const char *) tempBuffer ) == -1 )
 			{
 				//Ignore comments
 				if ( tempBuffer[0] == ';' )
@@ -502,11 +502,11 @@ static void AS_GetLocalSet( ambientSet_t &set )
 	//The other parameters of the set come in a specific order
 	while ( parsePos <= parseSize )
 	{
-		int iFieldsScanned = sscanf( parseBuffer+parsePos, "%s", &tempBuffer );
+		int iFieldsScanned = sscanf( parseBuffer+parsePos, "%s", tempBuffer );
 		if (iFieldsScanned <= 0)
 			return;
 
-		keywordID = AS_GetKeywordIDForString( (const char *) &tempBuffer );
+		keywordID = AS_GetKeywordIDForString( (const char *) tempBuffer );
 
 		//Find and parse the keyword info
 		switch ( keywordID )
@@ -534,7 +534,7 @@ static void AS_GetLocalSet( ambientSet_t &set )
 		default:
 
 			//Check to see if we've finished this group
-			if ( AS_GetSetNameIDForString( (const char *) &tempBuffer ) == -1 )
+			if ( AS_GetSetNameIDForString( (const char *) tempBuffer ) == -1 )
 			{
 				//Ignore comments
 				if ( tempBuffer[0] == ';' )
@@ -565,11 +565,11 @@ static void AS_GetBModelSet( ambientSet_t &set )
 	//The other parameters of the set come in a specific order
 	while ( parsePos <= parseSize )
 	{
-		int iFieldsScanned = sscanf( parseBuffer+parsePos, "%s", &tempBuffer );
+		int iFieldsScanned = sscanf( parseBuffer+parsePos, "%s", tempBuffer );
 		if (iFieldsScanned <= 0)
 			return;
 
-		keywordID = AS_GetKeywordIDForString( (const char *) &tempBuffer );
+		keywordID = AS_GetKeywordIDForString( (const char *) tempBuffer );
 
 		//Find and parse the keyword info
 		switch ( keywordID )
@@ -581,7 +581,7 @@ static void AS_GetBModelSet( ambientSet_t &set )
 		default:
 
 			//Check to see if we've finished this group
-			if ( AS_GetSetNameIDForString( (const char *) &tempBuffer ) == -1 )
+			if ( AS_GetSetNameIDForString( (const char *) tempBuffer ) == -1 )
 			{
 				//Ignore comments
 				if ( tempBuffer[0] == ';' )
@@ -634,19 +634,19 @@ static qboolean AS_ParseSet( int setID, CSetGroup *sg )
 			parsePos+=strlen(name)+1;	//Also take the following space out
 
 			//Get the set name (this MUST be first)
-			sscanf( parseBuffer+parsePos, "%s", &tempBuffer );
+			sscanf( parseBuffer+parsePos, "%s", tempBuffer );
 			AS_SkipLine();
 	
 			//Test the string against the precaches
 			if ( tempBuffer[0] )
 			{
 				//Not in our precache listings, so skip it
-				if ( ( pMap->find( (const char *) &tempBuffer ) == pMap->end() ) )
+				if ( ( pMap->find( (const char *) tempBuffer ) == pMap->end() ) )
 					continue;
 			}
 
 			//Create a new set
-			set = sg->AddSet( (const char *) &tempBuffer );
+			set = sg->AddSet( (const char *) tempBuffer );
 			
 			//Run the function to parse the data out
 			parseFuncs[setID]( *set );
@@ -675,14 +675,14 @@ static void AS_ParseHeader( void )
 
 	while ( parsePos <= parseSize )
 	{
-		sscanf( parseBuffer+parsePos, "%s", &tempBuffer );
+		sscanf( parseBuffer+parsePos, "%s", tempBuffer );
 
-		keywordID = AS_GetKeywordIDForString( (const char *) &tempBuffer );
+		keywordID = AS_GetKeywordIDForString( (const char *) tempBuffer );
 
 		switch ( keywordID )
 		{
 		case SET_KEYWORD_TYPE:
-			sscanf( parseBuffer+parsePos, "%s %s", &tempBuffer, &typeBuffer );
+			sscanf( parseBuffer+parsePos, "%s %s", tempBuffer, typeBuffer );
 
 			if ( !stricmp( (const char *) typeBuffer, "ambientSet" ) )
 			{

--- a/code/game/fields.h
+++ b/code/game/fields.h
@@ -11,14 +11,14 @@
 #define FFL_SPAWNTEMP		1
 #define MAX_GHOULINST_SIZE	16384
 
-#ifndef FOFS
-#define	FOFS(x) ((int)&(((gentity_t *)0)->x))	// usually already defined in qshared.h
+#ifndef  FOFS
+# define FOFS(x) offsetof(gentity_t,x)	// usually already defined in g_shared.h
 #endif
-#define	STOFS(x) ((int)&(((spawn_temp_t *)0)->x))
-#define	LLOFS(x) ((int)&(((level_locals_t *)0)->x))
-#define	CLOFS(x) ((int)&(((gclient_t *)0)->x))
-#define NPCOFS(x) ((int)&(((gNPC_t *)0)->x)) 
-#define VHOFS(x) ((int)&(((Vehicle_t *)0)->x)) 
+#define	STOFS(x) offsetof(spawn_temp_t,x)
+#define	LLOFS(x) offsetof(level_locals_t,x)
+#define	CLOFS(x) offsetof(gclient_t,x)
+#define NPCOFS(x) offsetof(gNPC_t,x) 
+#define VHOFS(x) offsetof(Vehicle_t,x) 
 
 //
 #define strFOFS(x)	 #x,FOFS(x)

--- a/code/game/g_shared.h
+++ b/code/game/g_shared.h
@@ -11,7 +11,7 @@
 #include "hitlocs.h"
 #include "bset.h"
 
-#define	FOFS(x) ((int)&(((gentity_t *)0)->x))
+#define FOFS(x) offsetof(gentity_t,x)
 
 #ifdef _XBOX
 #define MAX_NPC_WATER_UPDATE_PER_FRAME	2	// maxmum number of NPCs that will get updated water infromation per frame

--- a/code/qcommon/files_pc.cpp
+++ b/code/qcommon/files_pc.cpp
@@ -811,11 +811,13 @@ int FS_ReadFile( const char *qpath, void **buffer ) {
 
 	// PRECACE CHECKER!
 #ifndef FINAL_BUILD
+#ifndef FINAL_BUILD_PRECACHE
 	if (com_sv_running && com_sv_running->integer && cls.state >= CA_ACTIVE) {	//com_cl_running
 		if (strncmp(qpath,"menu/",5) ) {
 			Com_Printf( S_COLOR_MAGENTA"FS_ReadFile: %s NOT PRECACHED!\n", qpath );
 		}
 	}
+#endif
 #endif
 
 	FS_Read (buf, len, h);


### PR DESCRIPTION
This enabled FINAL_BUILD to suppress those distracting "not precached" warnings, and fixes/suppresses most of the compiler warnings.
